### PR TITLE
Up to 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
+## [1.1.2] - 2025-03-12
+
+### Added
+
+- added doc description about rfs_test_macro usage
+
+### Changed
+
+- The usage of the format! macro has been replaced with PathBuf functions in the test and code examples
+- Updated dependencies in Cargo.toml
+
 ## [1.1.1] - 2025-02-28
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rfs_tester"
-version = "1.1.1"
+version = "1.1.2"
 authors = ["Sergey Reshetnikov <shaman@simmirra.com>"]
 edition = "2021"
 repository = "https://github.com/greyshaman/rfs_tester"
@@ -20,9 +20,9 @@ After the tests are finished, the temporary directory will be deleted automatica
 [dependencies]
 rfs_test_macro = "1.1.1"
 rand = "0.9.0"
-serde = { version = "1.0.218", features = ["derive"] }
-serde_json = "1.0.137"
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.140"
 serde_yaml = "0.9.34"
-tokio = { version = "1.43.0", features = ["full"] }
+tokio = { version = "1.44.0", features = ["full"] }
 futures = "0.3.31"
 walkdir = "2.5.0"

--- a/src/rfs/fs_tester.rs
+++ b/src/rfs/fs_tester.rs
@@ -53,7 +53,7 @@ struct Permissions {
 ///     let tester = FsTester::new(config_str, ".")?;
 ///
 ///     tester.perform_fs_test(|dirname| {
-///         let file_path = format!("{}/test.txt", dirname);
+///         let file_path = std::path::PathBuf::from(dirname).join("test.txt");
 ///         let content = std::fs::read_to_string(file_path)?;
 ///         assert_eq!(content, "Hello, world!");
 ///         Ok(())
@@ -349,7 +349,7 @@ impl FsTester {
     /// ```rust
     /// # use rfs_tester::{FsTester, FsTesterError, FileContent };
     /// # use rfs_tester::config::{Configuration, ConfigEntry, DirectoryConf, FileConf, LinkConf};
-    /// let simple_conf_str = "---
+    /// let simple_conf_str = "
     ///   - !directory
     ///       name: test_doc_test_parser_yaml
     ///       content:
@@ -510,8 +510,9 @@ impl FsTester {
     ///
     /// ```rust
     /// # use std::fs;
+    /// # use std::path::PathBuf;
     /// # use rfs_tester::FsTester;
-    /// const YAML_DIR_WITH_TEST_FILE_FROM_CARGO_TOML: &str = "---
+    /// const YAML_DIR_WITH_TEST_FILE_FROM_CARGO_TOML: &str = "
     /// - !directory
     ///     name: test_doc_perform_fs_test
     ///     content:
@@ -524,7 +525,7 @@ impl FsTester {
     /// let tester = FsTester::new(YAML_DIR_WITH_TEST_FILE_FROM_CARGO_TOML, ".").expect("Incorrect config");
     /// tester.perform_fs_test(|dirname| {
     /// //                      ^^^^^^^ name with appended random at the end of name
-    ///   let inner_file_name = format!("{}/{}", dirname, "test_from_cargo.toml");
+    ///   let inner_file_name = PathBuf::from(dirname).join("test_from_cargo.toml");
     ///   let metadata = fs::metadata(inner_file_name)?;
     ///
     ///   assert!(metadata.len() > 0);

--- a/tests/basic_usage.rs
+++ b/tests/basic_usage.rs
@@ -17,7 +17,7 @@ fn basic_test_file_creation() {
 
     // Performs the test
     tester.perform_fs_test(|dirname| {
-        let file_path = format!("{}/test.txt", dirname);
+        let file_path = std::path::PathBuf::from(dirname).join("test.txt");
         let content = std::fs::read_to_string(file_path)?;
         assert_eq!(content, "Hello, world!");
         Ok(())

--- a/tests/file_creation.rs
+++ b/tests/file_creation.rs
@@ -14,7 +14,7 @@ const CONFIG: &str = r#"---
 
 #[rfs_test(config = CONFIG, start_point = ".")]
 fn link_creation_test(dirname: &str) -> std::io::Result<()> {
-    let file_path = format!("{dirname}/file_link.txt");
+    let file_path = std::path::PathBuf::from(dirname).join("file_link.txt");
     let meta = fs::metadata(file_path)?;
     assert!(meta.is_file());
     Ok(())

--- a/tests/macro_usage.rs
+++ b/tests/macro_usage.rs
@@ -13,7 +13,7 @@ use rfs_test_macro::rfs_test;
     start_point = "."
 )]
 fn file_creation_test_with_macro(dirname: &str) -> std::io::Result<()> {
-    let file_path = format!("{}/test.txt", dirname);
+    let file_path = std::path::PathBuf::from(dirname).join("test.txt");
     let content = std::fs::read_to_string(file_path)?;
     assert_eq!(content, "Hello, world!");
     Ok(())
@@ -36,8 +36,9 @@ fn file_creation_test_with_macro(dirname: &str) -> std::io::Result<()> {
     start_point = "."
 )]
 fn multiple_files_test(dirname: &str) -> std::io::Result<()> {
-    let file1_path = format!("{}/test1.txt", dirname);
-    let file2_path = format!("{}/test2.txt", dirname);
+    let current_dir = std::path::PathBuf::from(dirname);
+    let file1_path = current_dir.join("test1.txt");
+    let file2_path = current_dir.join("test2.txt");
     let content1 = std::fs::read_to_string(file1_path)?;
     let content2 = std::fs::read_to_string(file2_path)?;
     assert_eq!(content1, "File 1");

--- a/tests/macro_usage_with_const.rs
+++ b/tests/macro_usage_with_const.rs
@@ -1,6 +1,8 @@
+use std::path::PathBuf;
+
 use rfs_test_macro::rfs_test;
 
-const CONFIG: &str = r#"---
+const CONFIG: &str = r#"
     - !directory
         name: test
         content:
@@ -15,7 +17,7 @@ const CONFIG: &str = r#"---
     start_point = "."
 )]
 fn file_creation_test_macro_with_conf_in_const(dirname: &str) -> std::io::Result<()> {
-    let file_path = format!("{}/test.txt", dirname);
+    let file_path = PathBuf::from(dirname).join("test.txt");
     let content = std::fs::read_to_string(file_path)?;
     assert_eq!(content, "Hello, world!");
     Ok(())


### PR DESCRIPTION
### Added

- added doc description about `rfs_test_macro` usage

### Changed

- The usage of the format! macro has been replaced with `PathBuf` functions in the test and code examples
- Updated dependencies in `Cargo.toml`